### PR TITLE
Readme: change param name in callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ example both are used for demonstration.
 
     shinyalert(
       "Enter your name", type = "input",
-      callbackR = function(input) { message("Hello ", input) },
-      callbackJS = "function(input) { alert('Hello ' + input); }"
+      callbackR = function(response) { message("Hello ", response) },
+      callbackJS = "function(response) { alert('Hello ' + response); }"
     )
 
 Notice that the `callbackR` function accepts R code, while the
@@ -226,8 +226,8 @@ that case.
 
     shinyalert(
       "Enter your name", type = "input",
-      callbackR = function(input) { if(input != FALSE) message("Hello ", input) },
-      callbackJS = "function(input) { if (input !== false) { alert('Hello ' + input); } }"
+      callbackR = function(response) { if(input != FALSE) message("Hello ", response) },
+      callbackJS = "function(response) { if (input !== false) { alert('Hello ' + response); } }"
     )
 
 <h2 id="chaining">

--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ that case.
 
     shinyalert(
       "Enter your name", type = "input",
-      callbackR = function(response) { if(input != FALSE) message("Hello ", response) },
-      callbackJS = "function(response) { if (input !== false) { alert('Hello ' + response); } }"
+      callbackR = function(response) { if(response != FALSE) message("Hello ", response) },
+      callbackJS = "function(response) { if (response !== false) { alert('Hello ' + response); } }"
     )
 
 <h2 id="chaining">
@@ -242,7 +242,7 @@ the return value of a previous modal. For example:
 
     shinyalert(
       title = "What is your name?", type = "input",
-      callbackR = function(value) { shinyalert(paste("Welcome", value)) }
+      callbackR = function(response) { shinyalert(paste("Welcome", response)) }
     )
 
 <h2 id="rmd">

--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ example both are used for demonstration.
 
     shinyalert(
       "Enter your name", type = "input",
-      callbackR = function(x) { message("Hello ", x) },
-      callbackJS = "function(x) { alert('Hello ' + x); }"
+      callbackR = function(input) { message("Hello ", input) },
+      callbackJS = "function(input) { alert('Hello ' + input); }"
     )
 
 Notice that the `callbackR` function accepts R code, while the
@@ -226,8 +226,8 @@ that case.
 
     shinyalert(
       "Enter your name", type = "input",
-      callbackR = function(x) { if(x != FALSE) message("Hello ", x) },
-      callbackJS = "function(x) { if (x !== false) { alert('Hello ' + x); } }"
+      callbackR = function(input) { if(input != FALSE) message("Hello ", input) },
+      callbackJS = "function(input) { if (input !== false) { alert('Hello ' + input); } }"
     )
 
 <h2 id="chaining">


### PR DESCRIPTION
Rename `x` to `input` for better example code readability.