### PR TITLE
add support for mathjax

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 - Fixed UI bug: vertical scrollbar incorrectly appeared when dialog has no buttons (#49)
 - Fixed UI bug: radio buttons and checkboxes did not render correctly (#55)
 - New feature: added `session` parameter to allow advanced uses of shinyalert where the Shiny session isn't immediately accessible (thanks @galachad)
+- New feature: `shinyalert` now supports MathJax to render equations, provided that `withMathJax()` is put in the UI (#54).
 
 # shinyalert 2.0.0 (2020-09-11)
 

--- a/inst/www/srcjs/shinyalert.js
+++ b/inst/www/srcjs/shinyalert.js
@@ -65,6 +65,9 @@ Shiny.addCustomMessageHandler('shinyalert.show', function(params) {
     }, timer, swal_id);
   }
 
+  // Enable MathJax
+  MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
+
   // Modals that need a scrollbar get initialized at the bottom, so let's scroll to top
   $('.sweet-alert')[0].scrollTop = 0;
 });

--- a/inst/www/srcjs/shinyalert.js
+++ b/inst/www/srcjs/shinyalert.js
@@ -66,7 +66,9 @@ Shiny.addCustomMessageHandler('shinyalert.show', function(params) {
   }
 
   // Enable MathJax
-  MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
+  if (window.MathJax) {
+    MathJax.Hub.Queue(['Typeset', MathJax.Hub]);
+  }
 
   // Modals that need a scrollbar get initialized at the bottom, so let's scroll to top
   $('.sweet-alert')[0].scrollTop = 0;


### PR DESCRIPTION
This PR adds support for MathJax, as requested in #54. Here's an example that works now:
```
library(shiny)

ui <- fluidPage(
  withMathJax(),
  actionButton("btn", "show modal")
)

server <- function(input, output, session) {
  observeEvent(input$btn, {
    shinyalert(
      text = div("$$\\sqrt{2}$$"),
      html = TRUE
    )
  })
}

shinyApp(ui, server)
```
I placed the line at the end of the JS function, but I don't have particular reasons for that. Let me know if you want me to change or add something.